### PR TITLE
Another price approach using a min tokens sold

### DIFF
--- a/packages/foundry/contracts/PredictionMarketChallenge.sol
+++ b/packages/foundry/contracts/PredictionMarketChallenge.sol
@@ -23,7 +23,7 @@ contract PredictionMarketChallenge is Ownable {
     error PredictionMarketChallenge__ETHTransferFailed();
     error PredictionMarketChallenge__InsufficientBalance(uint256 _tradingAmount, uint256 _userBalance);
     error PredictionMarketChallenge__InsufficientAllowance(uint256 _tradingAmount, uint256 _allowance);
-
+    error PredictionMarketChallenge__InsufficientLiquidity();
     //////////////////////////
     /// State Variables //////
     //////////////////////////
@@ -37,7 +37,7 @@ contract PredictionMarketChallenge is Ownable {
 
     address public immutable i_oracle;
     uint256 public immutable i_initialTokenValue;
-    uint256 public immutable i_virtualTrades;
+    uint256 public immutable i_virtualTradePercentage;
     PredictionMarketToken public immutable i_optionToken1;
     PredictionMarketToken public immutable i_optionToken2;
 
@@ -88,7 +88,7 @@ contract PredictionMarketChallenge is Ownable {
         s_ethCollateral = msg.value;
 
         uint256 initialTokenAmount = (msg.value * PRECISION) / _initialTokenValue;
-        i_virtualTrades = initialTokenAmount / 10;
+        i_virtualTradePercentage = 10;
         i_optionToken1 = new PredictionMarketToken("Yes", "Y", initialTokenAmount);
         i_optionToken2 = new PredictionMarketToken("No", "N", initialTokenAmount);
     }
@@ -285,54 +285,67 @@ contract PredictionMarketChallenge is Ownable {
         view
         returns (uint256)
     {
-        uint256 currentTokenReserve;
-        uint256 currentOtherTokenReserve;
-
-        if (_option == Option.YES) {
-            currentTokenReserve = i_optionToken1.balanceOf(address(this));
-            currentOtherTokenReserve = i_optionToken2.balanceOf(address(this));
-        } else {
-            currentTokenReserve = i_optionToken2.balanceOf(address(this));
-            currentOtherTokenReserve = i_optionToken1.balanceOf(address(this));
-        }
+        (uint256 currentTokenReserve, uint256 currentOtherTokenReserve) = _getCurrentReserves(_option);
 
         /// Ensure sufficient liquidity when buying
         if (!_isSelling) {
-            require(currentTokenReserve >= _tradingAmount, "Not enough liquidity");
+            if (currentTokenReserve < _tradingAmount) {
+                revert PredictionMarketChallenge__InsufficientLiquidity();
+            }
         }
 
         uint256 totalTokenSupply = i_optionToken1.totalSupply();
-        uint256 currentTokenSold = totalTokenSupply - currentTokenReserve;
+        uint256 virtualTrades = _getVirtualTrades();
+        uint256 currentTokenSoldBefore = totalTokenSupply - currentTokenReserve;
         uint256 currentOtherTokenSold = totalTokenSupply - currentOtherTokenReserve;
-        uint256 totalTokensSoldStart = currentTokenSold + currentOtherTokenSold;
 
-        uint256 minNotSoldStart = 0;
-        if (totalTokensSoldStart < i_virtualTrades) {
-            minNotSoldStart = i_virtualTrades - totalTokensSoldStart;
-        }
+        uint256 totalTokensSoldBefore = currentTokenSoldBefore + currentOtherTokenSold;
 
-        /// Compute new reserves after trade
-        uint256 newReserve = _isSelling ? currentTokenReserve + _tradingAmount : currentTokenReserve - _tradingAmount;
-        uint256 newSupply = totalTokenSupply - newReserve;
+        uint256 virtualAmountBefore = _calculateVirtualAmount(totalTokensSoldBefore, virtualTrades);
 
-        uint256 totalTokensSoldEnd = _isSelling
-            ? totalTokensSoldStart - _tradingAmount
-            : totalTokensSoldStart + _tradingAmount;
-        uint256 minNotSoldEnd = 0;
-        if (totalTokensSoldEnd < i_virtualTrades) {
-            minNotSoldEnd = i_virtualTrades - totalTokensSoldEnd;
-        }
+        uint256 probabilityBefore =
+            _calculateProbability(currentTokenSoldBefore, virtualAmountBefore, totalTokensSoldBefore);
 
-        /// Probability calculations with virtual liquidity
-        uint256 denominatorStart = totalTokensSoldStart + minNotSoldStart;
-        uint256 probabilityStart = ((currentTokenSold + (minNotSoldStart / 2)) * PRECISION) / denominatorStart;
+        /// After trade
+        uint256 currentTokenReserveAfter =
+            _isSelling ? currentTokenReserve + _tradingAmount : currentTokenReserve - _tradingAmount;
+        uint256 currentTokenSoldAfter = totalTokenSupply - currentTokenReserveAfter;
 
-        uint256 denominatorEnd = totalTokensSoldEnd + minNotSoldEnd;
-        uint256 probabilityEnd = ((newSupply + (minNotSoldEnd / 2)) * PRECISION) / denominatorEnd;
+        uint256 totalTokensSoldAfter =
+            _isSelling ? totalTokensSoldBefore - _tradingAmount : totalTokensSoldBefore + _tradingAmount;
+        uint256 virtualAmountAfter = _calculateVirtualAmount(totalTokensSoldAfter, virtualTrades);
+
+        uint256 probabilityAfter =
+            _calculateProbability(currentTokenSoldAfter, virtualAmountAfter, totalTokensSoldAfter);
 
         /// Compute final price
-        uint256 probabilityAvg = (probabilityStart + probabilityEnd) / 2;
+        uint256 probabilityAvg = (probabilityBefore + probabilityAfter) / 2;
         return (i_initialTokenValue * probabilityAvg * _tradingAmount) / (PRECISION * PRECISION);
+    }
+
+    function _getCurrentReserves(Option _option) private view returns (uint256, uint256) {
+        if (_option == Option.YES) {
+            return (i_optionToken1.balanceOf(address(this)), i_optionToken2.balanceOf(address(this)));
+        } else {
+            return (i_optionToken2.balanceOf(address(this)), i_optionToken1.balanceOf(address(this)));
+        }
+    }
+
+    function _getVirtualTrades() private view returns (uint256) {
+        return i_optionToken1.totalSupply() * i_virtualTradePercentage / 100;
+    }
+
+    function _calculateVirtualAmount(uint256 _totalTokensSold, uint256 _virtualTrades) private pure returns (uint256) {
+        return _totalTokensSold < _virtualTrades ? _virtualTrades - _totalTokensSold : 0;
+    }
+
+    function _calculateProbability(uint256 tokensSold, uint256 virtualAmount, uint256 totalSold)
+        private
+        pure
+        returns (uint256)
+    {
+        uint256 denominator = totalSold + virtualAmount;
+        return ((tokensSold + (virtualAmount / 2)) * PRECISION) / denominator;
     }
 
     /////////////////////////

--- a/packages/foundry/test/PredictionMarketChallenge.t.sol
+++ b/packages/foundry/test/PredictionMarketChallenge.t.sol
@@ -7,7 +7,7 @@ import { PredictionMarketToken } from "../contracts/PredictionMarketToken.sol";
 
 contract PredictionMarketChallengeTest is Test {
     PredictionMarketChallenge public predictionMarket;
-    uint256 initialLiquidity = 10 ether;
+    uint256 initialLiquidity = 1 ether;
     uint256 initialTokenValue = 0.01 ether;
     address oracle = address(1);
     address gambler1 = address(2);
@@ -41,7 +41,7 @@ contract PredictionMarketChallengeTest is Test {
     }
 
     function testBuyTokenWithETH() public {
-        uint256 tradingAmount = 100 ether;
+        uint256 tradingAmount = 10 ether;
         uint256 lpRevenueBefore = predictionMarket.s_lpTradingRevenue();
         uint256 yesTokenBalanceBefore = predictionMarket.i_optionToken1().balanceOf(gambler1);
 
@@ -191,5 +191,16 @@ contract PredictionMarketChallengeTest is Test {
         vm.prank(oracle);
         vm.expectRevert(PredictionMarketChallenge.PredictionMarketChallenge__InsufficientTokenReserve.selector);
         predictionMarket.removeLiquidity(excessiveAmount);
+    }
+
+    function testPriceCalculation() public {
+        uint256 tradingAmount = 10 ether;
+        uint256 ethNeeded = predictionMarket.getBuyPriceInEth(PredictionMarketChallenge.Option.YES, tradingAmount);
+        console.log("ethNeeded", ethNeeded);
+
+        testBuyTokenWithETH();
+
+        uint256 ethNeeded2 = predictionMarket.getBuyPriceInEth(PredictionMarketChallenge.Option.YES, tradingAmount);
+        console.log("ethNeeded2", ethNeeded2);
     }
 }

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -7,7 +7,7 @@ import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 const deployedContracts = {
   31337: {
     PredictionMarketChallenge: {
-      address: "0xcac3efea764287acc5dc551f1554a95ad8788d96",
+      address: "0x107d6f280a05f07b59039143ca21e3f917aafa30",
       abi: [
         {
           type: "constructor",
@@ -320,19 +320,6 @@ const deployedContracts = {
         },
         {
           type: "function",
-          name: "resolveMarketAndWithdraw",
-          inputs: [],
-          outputs: [
-            {
-              name: "ethRedeemed",
-              type: "uint256",
-              internalType: "uint256",
-            },
-          ],
-          stateMutability: "nonpayable",
-        },
-        {
-          type: "function",
           name: "s_ethCollateral",
           inputs: [],
           outputs: [
@@ -413,6 +400,31 @@ const deployedContracts = {
           ],
           outputs: [],
           stateMutability: "nonpayable",
+        },
+        {
+          type: "event",
+          name: "MarketResolved",
+          inputs: [
+            {
+              name: "resolver",
+              type: "address",
+              indexed: true,
+              internalType: "address",
+            },
+            {
+              name: "ethRedeemed",
+              type: "uint256",
+              indexed: false,
+              internalType: "uint256",
+            },
+            {
+              name: "totalEthToSend",
+              type: "uint256",
+              indexed: false,
+              internalType: "uint256",
+            },
+          ],
+          anonymous: false,
         },
         {
           type: "event",
@@ -636,7 +648,7 @@ const deployedContracts = {
         },
       ],
       inheritedFunctions: {},
-      deploymentFile: "run-1740991252.json",
+      deploymentFile: "run-1741168024.json",
       deploymentScript: "Deploy.s.sol",
     },
   },

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -7,7 +7,7 @@ import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 const deployedContracts = {
   31337: {
     PredictionMarketChallenge: {
-      address: "0x107d6f280a05f07b59039143ca21e3f917aafa30",
+      address: "0x9aeebff653c45abafb7bf85ee9e800b790dd0f71",
       abi: [
         {
           type: "constructor",
@@ -170,19 +170,6 @@ const deployedContracts = {
         },
         {
           type: "function",
-          name: "i_virtualTrades",
-          inputs: [],
-          outputs: [
-            {
-              name: "",
-              type: "uint256",
-              internalType: "uint256",
-            },
-          ],
-          stateMutability: "view",
-        },
-        {
-          type: "function",
           name: "owner",
           inputs: [],
           outputs: [
@@ -320,6 +307,19 @@ const deployedContracts = {
         },
         {
           type: "function",
+          name: "resolveMarketAndWithdraw",
+          inputs: [],
+          outputs: [
+            {
+              name: "ethRedeemed",
+              type: "uint256",
+              internalType: "uint256",
+            },
+          ],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "function",
           name: "s_ethCollateral",
           inputs: [],
           outputs: [
@@ -400,31 +400,6 @@ const deployedContracts = {
           ],
           outputs: [],
           stateMutability: "nonpayable",
-        },
-        {
-          type: "event",
-          name: "MarketResolved",
-          inputs: [
-            {
-              name: "resolver",
-              type: "address",
-              indexed: true,
-              internalType: "address",
-            },
-            {
-              name: "ethRedeemed",
-              type: "uint256",
-              indexed: false,
-              internalType: "uint256",
-            },
-            {
-              name: "totalEthToSend",
-              type: "uint256",
-              indexed: false,
-              internalType: "uint256",
-            },
-          ],
-          anonymous: false,
         },
         {
           type: "event",
@@ -648,7 +623,7 @@ const deployedContracts = {
         },
       ],
       inheritedFunctions: {},
-      deploymentFile: "run-1741168024.json",
+      deploymentFile: "run-1740776237.json",
       deploymentScript: "Deploy.s.sol",
     },
   },


### PR DESCRIPTION
This new price strategy has a minimum tokens sold value (i_virtualTrades).

If the total tokens sold (counting both options) is more than this minimum, the price is the same as before.

If the total tokens sold is less than this minimum, the difference between this minimum and the real tokens sold amount is split in two, like both tokens were sold equally.

This means the price for the first tokens bought will not change too much.